### PR TITLE
Add exception to compact notification level

### DIFF
--- a/lib/resque/failure/notification.rb
+++ b/lib/resque/failure/notification.rb
@@ -35,26 +35,26 @@ module Resque
 
       # Returns the formatted exception linked to the failed job
       #
-      # backtrace: add backtrace or not
-      def msg_exception(backtrace)
-        exception = @failure.exception
+      def msg_exception
+        "Exception:\n#{exception}"
+      end
 
-        str = "Exception:\n#{exception}"
-        if backtrace
-          str += "\n#{format_message(exception.backtrace)}"
-        end
+      # Returns the formatted exception linked to the failed job with backtrace
+      #
+      def msg_exception_with_backtrace
+        "#{msg_exception}\n#{format_message(exception.backtrace)}"
       end
 
       # Returns the verbose text notification
       #
       def verbose
-        "#{msg_worker}\n#{msg_payload}\n#{msg_exception(true)}"
+        "#{msg_worker}\n#{msg_payload}\n#{msg_exception_with_backtrace}"
       end
 
       # Returns the compact text notification
       #
       def compact
-        "#{msg_worker}\n#{msg_payload}\n#{msg_exception(false)}"
+        "#{msg_worker}\n#{msg_payload}\n#{msg_exception}"
       end
 
       # Returns the minimal text notification
@@ -67,6 +67,9 @@ module Resque
         obj.map{ |l| "\t" + l }.join('\n')
       end
 
+      def exception
+        @failure.exception
+      end
     end
   end
 end

--- a/spec/resque/failure/notification_spec.rb
+++ b/spec/resque/failure/notification_spec.rb
@@ -12,7 +12,7 @@ describe Resque::Failure::Notification do
       def expected_notification
         {
           verbose: "worker failed processing queue\nPayload:\n\t\"payload\"\nException:\nexception\n\tbacktrace",
-          compact: "worker failed processing queue\nPayload:\n\t\"payload\"\n",
+          compact: "worker failed processing queue\nPayload:\n\t\"payload\"\nException:\nexception",
           minimal: "worker failed processing queue\nPayload:\n\t\"payload\""
         }
       end


### PR DESCRIPTION
The method `msg_exception` is supposed to return an exception message if `backtrace` flag is false, but returned nil. Also, boolean arguments should be avoided, better to separate the method in 2.