### PR TITLE
Require notification

### DIFF
--- a/lib/resque/failure/slack.rb
+++ b/lib/resque/failure/slack.rb
@@ -2,6 +2,8 @@ require 'resque'
 require 'uri'
 require 'net/http'
 
+require 'resque/failure/notification'
+
 module Resque
   module Failure
     class Slack < Base


### PR DESCRIPTION
I was trying to use the plugin (with ruby `2.5.0` and resque `2.0.0`) and I was getting the following error:

```
uninitialized constant Resque::Failure::Slack::Notification
```

This import fixes the issue.